### PR TITLE
Interpret 'nodeProcessCommandLine' as a relative path if it starts with '.'

### DIFF
--- a/src/iisnode/cmoduleconfiguration.cpp
+++ b/src/iisnode/cmoduleconfiguration.cpp
@@ -1268,6 +1268,19 @@ HRESULT CModuleConfiguration::GetConfig(IHttpContext* context, CModuleConfigurat
 
         CheckError(CModuleConfiguration::ApplyYamlConfigOverrides(context, c));
 
+		if (c->nodeProcessCommandLine && c->nodeProcessCommandLine[0] == L'.')
+		{
+			LPWSTR origcmd = c->nodeProcessCommandLine;
+			DWORD scriptTranslatedLength = 0;
+			LPCWSTR scriptTranslated = context->GetScriptTranslated(&scriptTranslatedLength);
+			ErrorIf(NULL == (c->nodeProcessCommandLine = new WCHAR[scriptTranslatedLength + wcslen(origcmd) + 1]), ERROR_NOT_ENOUGH_MEMORY);
+			wcscpy(c->nodeProcessCommandLine, scriptTranslated);
+			while (scriptTranslatedLength > 0 && c->nodeProcessCommandLine[scriptTranslatedLength] != L'\\')
+				scriptTranslatedLength--;
+			wcscpy(c->nodeProcessCommandLine + scriptTranslatedLength + 1, origcmd);
+			delete [] origcmd;
+		}
+
         // generate debugger related config based on debuggerVirtualDir value.
         CheckError(CModuleConfiguration::GenerateDebuggerConfig(context, c));
 


### PR DESCRIPTION
This patch i'm currently using to simplify deployment a little. I can now deploy a complete app (with private node.exe and web.config) by unzipping a zip file on our web server.

Is there interest to merge this (or something like it) into iisnode?