### PR TITLE
new Buffer -> Buffer.from

### DIFF
--- a/src/scripts/interceptor.js
+++ b/src/scripts/interceptor.js
@@ -166,12 +166,12 @@
             }
             else {
                 data = data.toString().replace(/\n/g, '\r\n');
-		encoding = (typeof encoding === 'string' ? encoding : 'utf8');
-		if (Buffer.hasOwnProperty('from')) {
+                encoding = (typeof encoding === 'string' ? encoding : 'utf8');
+                if (Buffer.hasOwnProperty('from')) {
                     return Buffer.from(data, encoding);
-		} else {
-		    return new Buffer(data, encoding);	
-		}
+                } else {
+                    return new Buffer(data, encoding);
+                }
             }
         };
 

--- a/src/scripts/interceptor.js
+++ b/src/scripts/interceptor.js
@@ -166,7 +166,7 @@
             }
             else {
                 data = data.toString().replace(/\n/g, '\r\n');
-                return new Buffer(data, typeof encoding === 'string' ? encoding : 'utf8');
+                return Buffer.from(data, typeof encoding === 'string' ? encoding : 'utf8');
             }
         };
 

--- a/src/scripts/interceptor.js
+++ b/src/scripts/interceptor.js
@@ -166,7 +166,12 @@
             }
             else {
                 data = data.toString().replace(/\n/g, '\r\n');
-                return Buffer.from(data, typeof encoding === 'string' ? encoding : 'utf8');
+		encoding = (typeof encoding === 'string' ? encoding : 'utf8');
+		if (Buffer.hasOwnProperty('from')) {
+                    return Buffer.from(data, encoding);
+		} else {
+		    return new Buffer(data, encoding);	
+		}
             }
         };
 


### PR DESCRIPTION
from https://github.com/tjanczuk/iisnode/pull/636

---

`new Buffer(string, encoding)` is [deprecated](https://nodejs.org/api/buffer.html#buffer_new_buffer_string_encoding) in Node v6
it changes to [`Buffer.from(string, encoding)`](https://nodejs.org/api/buffer.html#buffer_class_method_buffer_from_string_encoding)