### PR TITLE
Clean old handle before creating a new one

### DIFF
--- a/src/iisnode/cprotocolbridge.cpp
+++ b/src/iisnode/cprotocolbridge.cpp
@@ -626,6 +626,12 @@ void WINAPI CProtocolBridge::CreateNamedPipeConnection(DWORD error, DWORD bytesT
 
     if (INVALID_HANDLE_VALUE == pipe)
     {
+        // Clean up old pipe handle, otherwise there will be a handle leak
+        HANDLE oldPipe = ctx->GetPipe();
+        if (oldPipe != NULL && oldPipe != INVALID_HANDLE_VALUE) {
+            CloseHandle(oldPipe);
+        }
+		
         ErrorIf(INVALID_HANDLE_VALUE == (pipe = CreateFile(
             ctx->GetNodeProcess()->GetNamedPipeName(),
             GENERIC_READ | GENERIC_WRITE,


### PR DESCRIPTION
If communication from a connection from the pool fails, the code was trying to rightly create a new named pipe but did not have clean up for the old pipe on which the communication failed. This was causing a file handle leak.

These changes make sure the old pipe file handle is cleaned and closed before we try creating a new one.